### PR TITLE
Add fastapi document scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# document_scanner
+# Document Scanner
+
+Simple web-based document scanner that captures images from your device camera and saves them to a local folder using a small FastAPI backend.
+
+## Folder Structure
+
+```
+camera-scanner/
+├── index.html        # Frontend UI
+├── script.js         # Camera access and capture logic
+├── styles.css        # Basic styles
+└── backend/
+    ├── server.py     # FastAPI backend server
+    └── saved_docs/   # Folder where images are stored
+```
+
+## Running
+
+1. Install dependencies (preferably in a virtual environment):
+   ```bash
+   pip install fastapi uvicorn
+   ```
+
+2. Start the backend server from the `camera-scanner/backend` directory:
+   ```bash
+   uvicorn server:app --reload
+   ```
+   The server will run on `http://localhost:8000/` by default.
+
+3. Open the same URL in your desktop or phone browser connected to the same network. Grant camera permissions and start capturing documents. Each capture is saved in the `saved_docs` directory.
+

--- a/camera-scanner/backend/server.py
+++ b/camera-scanner/backend/server.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+import base64
+from datetime import datetime
+from pathlib import Path
+
+app = FastAPI()
+
+# Serve frontend files
+app.mount("/", StaticFiles(directory=Path(__file__).resolve().parent.parent, html=True), name="static")
+
+SAVE_DIR = Path(__file__).resolve().parent / "saved_docs"
+SAVE_DIR.mkdir(parents=True, exist_ok=True)
+
+@app.post("/save-image")
+async def save_image(req: Request):
+    data = await req.json()
+    img_data = data['image'].split(',')[1]
+    img_bytes = base64.b64decode(img_data)
+    filename = SAVE_DIR / f"doc_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
+    with open(filename, 'wb') as f:
+        f.write(img_bytes)
+    return {"status": "saved", "file": str(filename)}

--- a/camera-scanner/index.html
+++ b/camera-scanner/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document Scanner</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <h1>Document Scanner</h1>
+    <video id="video" autoplay></video>
+    <button id="snap">Capture</button>
+    <canvas id="canvas" style="display:none;"></canvas>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/camera-scanner/script.js
+++ b/camera-scanner/script.js
@@ -1,0 +1,28 @@
+navigator.mediaDevices.getUserMedia({ video: true })
+  .then(stream => {
+    const video = document.getElementById('video');
+    video.srcObject = stream;
+    video.play();
+  })
+  .catch(err => console.error('Error accessing camera:', err));
+
+const snapBtn = document.getElementById('snap');
+
+snapBtn.onclick = () => {
+  const canvas = document.getElementById('canvas');
+  const video = document.getElementById('video');
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(video, 0, 0);
+
+  const dataURL = canvas.toDataURL('image/png');
+  fetch('/save-image', {
+    method: 'POST',
+    body: JSON.stringify({ image: dataURL }),
+    headers: { 'Content-Type': 'application/json' }
+  })
+  .then(resp => resp.json())
+  .then(data => console.log('Saved', data))
+  .catch(err => console.error('Error saving image:', err));
+};

--- a/camera-scanner/styles.css
+++ b/camera-scanner/styles.css
@@ -1,0 +1,18 @@
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+
+video {
+  width: 100%;
+  max-width: 400px;
+  border: 1px solid #ccc;
+}
+
+button {
+  margin-top: 10px;
+  padding: 10px 20px;
+  font-size: 16px;
+}


### PR DESCRIPTION
## Summary
- implement a simple document scanner
- include front-end camera capture logic
- create FastAPI backend to store images
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684700691eec832ba32a506b514050ad