### PR TITLE
Enable HTTPS with self-signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ camera-scanner/
    pip install fastapi uvicorn
    ```
 
-2. Start the backend server from the `camera-scanner/backend` directory:
+2. Start the server from the repository root with HTTPS support (a self-signed
+   certificate will be generated automatically if needed):
    ```bash
-   uvicorn server:app --reload
+   python server.py
    ```
-   The server will run on `http://localhost:8000/` by default.
+   The server will run on `https://localhost:8000/`.
 
 3. Open the same URL in your desktop or phone browser connected to the same network. Grant camera permissions and start capturing documents. Each capture is saved in the `saved_docs` directory.
 


### PR DESCRIPTION
## Summary
- generate a self-signed certificate automatically
- run the FastAPI server with HTTPS enabled
- update documentation to use the new HTTPS server

## Testing
- `python -m py_compile server.py camera-scanner/backend/server.py`

------
https://chatgpt.com/codex/tasks/task_e_684705719b8c832ba132816234b2144f